### PR TITLE
remove assigning level onto logger instance which is not exist

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -41,7 +41,7 @@ class Domain < ActiveRecord::Base
 
     attr_accessor :importing
     attr_accessible :user_id, :name, :master, :last_check, :notified_serial, :account, :ttl, :notes, :authority_type, :addressing_type, :view_id, \
-    :primary_ns, :contact, :refresh, :retry, :expire, :minimum
+    :primary_ns, :contact, :refresh, :retry, :expire, :minimum, :importing
 
     audited :protect => false
     has_associated_audits

--- a/app/models/soa.rb
+++ b/app/models/soa.rb
@@ -38,7 +38,7 @@ class SOA < Record
     before_validation :set_content
     after_initialize  :update_convenience_accessors
 
-    attr_accessible  :domain_id, :type, :name, :ttl, :prio, :content, *ACCESSIBLE_SOA_FIELDS
+    attr_accessible  :domain_id, :type, :name, :ttl, :prio, :content, *ACCESSIBLE_SOA_FIELDS, :importing
 
     # this allows us to have these convenience attributes act like any other
     # column in terms of validations

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,8 +5,8 @@ development:
   adapter:  mysql2
   database: globodns
   host: localhost
-  username: globodns
-  password: "aWZ4G8rTPDsF7BHF"
+  username: root
+  password:
 
 # Warning: The database defined as 'test' will be erased and
 # re-generated from your development database when you run 'rake'.
@@ -15,15 +15,15 @@ test:
   adapter:  mysql2
   database: globodns_test
   host: localhost
-  username: globodns
-  password: "aWZ4G8rTPDsF7BHF"
+  username: root
+  password:
 
 production:
   adapter:  mysql2
   database: globodns_prod
   socket:   /var/lib/mysql/mysql.sock
-  username: globodns_prod
-  password: "pztBrCYH2vrQ85"
+  username: globodns
+  password: ""
 
 <%
   additional_environments = '/mnt/dbmigrate/globodns/globodns.yml'

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,8 +5,8 @@ development:
   adapter:  mysql2
   database: globodns
   host: localhost
-  username: root
-  password:
+  username: globodns
+  password: "aWZ4G8rTPDsF7BHF"
 
 # Warning: The database defined as 'test' will be erased and
 # re-generated from your development database when you run 'rake'.
@@ -15,15 +15,15 @@ test:
   adapter:  mysql2
   database: globodns_test
   host: localhost
-  username: root
-  password:
+  username: globodns
+  password: "aWZ4G8rTPDsF7BHF"
 
 production:
   adapter:  mysql2
   database: globodns_prod
   socket:   /var/lib/mysql/mysql.sock
-  username: globodns
-  password: ""
+  username: globodns_prod
+  password: "pztBrCYH2vrQ85"
 
 <%
   additional_environments = '/mnt/dbmigrate/globodns/globodns.yml'

--- a/config/globodns.yml
+++ b/config/globodns.yml
@@ -6,9 +6,10 @@ development: &devconf
         ipaddr:          '127.0.0.1'
         port:            53
         rndc_port:       953
-        chroot_dir:      '/var/named/chroot'
-        zones_dir:       '/var/named' 
-        named_conf_file: "/etc/named.conf"
+        chroot_dir:      '/etc/named'
+        zones_dir:       '/var/named'
+        named_conf_file: '/etc/named.conf'  # must be inside zones_dir
+        named_conf_link: '/etc/named.conf'  # can be anywhere
         export_chroot_dir:    <%= Rails.root.join('tmp', 'named', 'chroot_master') %>
 
       slaves:
@@ -22,6 +23,7 @@ development: &devconf
           zones_dir:        '/var/named'
           #zones_dir:        '/etc/named'
           named_conf_file:  '/etc/named/named.conf'  # must be inside zones_dir
+          named_conf_link:  '/etc/named.conf'  # can be anywhere
           export_chroot_dir: <%= Rails.root.join('tmp', 'named', 'chroot_slave1') %>
 
         - user:             'globodns'
@@ -32,6 +34,7 @@ development: &devconf
           chroot_dir:       '/var/named/chroot'
           zones_dir:        '/etc/named'
           named_conf_file:  '/etc/named/named.conf'  # must be inside zones_dir
+          named_conf_link:  '/etc/named.conf'  # can be anywhere
           export_chroot_dir: <%= Rails.root.join('tmp', 'named', 'chroot_slave2') %>
 
     bind_user:                   'named'

--- a/config/globodns.yml
+++ b/config/globodns.yml
@@ -7,11 +7,9 @@ development: &devconf
         port:            53
         rndc_port:       953
         #chroot_dir:      '/etc/named'
-        chroot_dir:      '/'
-        #chroot_dir:      '/var/named/chroot'
-        named_conf_dir:  '/etc/named'
-        zones_dir:       '/var/named'
-        named_conf_file: '/etc/named/named.conf'  # must be inside zones_dir
+        chroot_dir:      '/var/named/chroot'
+        zones_dir:       '/var/named' 
+        named_conf_file: "/etc/named/named.conf"  # must be inside zones_dir
         named_conf_link: '/etc/named.conf'  # can be anywhere
         export_chroot_dir:    <%= Rails.root.join('tmp', 'named', 'chroot_master') %>
 

--- a/config/globodns.yml
+++ b/config/globodns.yml
@@ -2,37 +2,36 @@ development: &devconf
     bind:
       master:
         user:            'globodns'
-        host:            'master'
-        ipaddr:          '192.168.0.100'
+        host:            'dns01'
+        ipaddr:          '127.0.0.1'
         port:            53
         rndc_port:       953
         chroot_dir:      '/var/named/chroot'
-        zones_dir:       '/etc/named'
-        named_conf_file: '/etc/named/named.conf'  # must be inside zones_dir
-        named_conf_link: '/etc/named.conf'  # can be anywhere
+        zones_dir:       '/var/named' 
+        named_conf_file: "/etc/named.conf"
         export_chroot_dir:    <%= Rails.root.join('tmp', 'named', 'chroot_master') %>
 
       slaves:
         - user:             'globodns'
-          host:             'slave0' ### empty means you don't have slave
-          ipaddr:           '192.168.0.101'
-          port:             5354
-          rndc_port:        5954
-          chroot_dir:       '/var/named/chroot'
-          zones_dir:        '/etc/named'
+          host:             ''
+          #host:             'slave0' ### empty means you don't have slave
+          ipaddr:           '172.16.0.3'
+          port:             53
+          rndc_port:        954
+          chroot_dir:       '/etc/named'
+          zones_dir:        '/var/named'
+          #zones_dir:        '/etc/named'
           named_conf_file:  '/etc/named/named.conf'  # must be inside zones_dir
-          named_conf_link:  '/etc/named.conf'  # can be anywhere
           export_chroot_dir: <%= Rails.root.join('tmp', 'named', 'chroot_slave1') %>
 
         - user:             'globodns'
-          host:             'slave1' ### empty means you don't have slave
+          host:             '' ### empty means you don't have slave
           ipaddr:           '192.168.0.102'
           port:             5354
           rndc_port:        5954
           chroot_dir:       '/var/named/chroot'
           zones_dir:        '/etc/named'
           named_conf_file:  '/etc/named/named.conf'  # must be inside zones_dir
-          named_conf_link:  '/etc/named.conf'  # can be anywhere
           export_chroot_dir: <%= Rails.root.join('tmp', 'named', 'chroot_slave2') %>
 
     bind_user:                   'named'
@@ -53,6 +52,7 @@ development: &devconf
     slaves_file:            'slaves.conf'
     forwards_dir:           'forwards'
     forwards_file:          'forwards.conf'
+    views_dir:              'views'
     views_file:             'views.conf'
     subdir_depth:           3
 

--- a/config/globodns.yml
+++ b/config/globodns.yml
@@ -2,32 +2,30 @@ development: &devconf
     bind:
       master:
         user:            'globodns'
-        host:            'dns01'
-        ipaddr:          '127.0.0.1'
+        host:            'master'
+        ipaddr:          '192.168.0.100'
         port:            53
         rndc_port:       953
-        chroot_dir:      '/etc/named'
-        zones_dir:       '/var/named'
-        named_conf_file: '/etc/named.conf'  # must be inside zones_dir
+        chroot_dir:      '/var/named/chroot'
+        zones_dir:       '/etc/named'
+        named_conf_file: '/etc/named/named.conf'  # must be inside zones_dir
         named_conf_link: '/etc/named.conf'  # can be anywhere
         export_chroot_dir:    <%= Rails.root.join('tmp', 'named', 'chroot_master') %>
 
       slaves:
         - user:             'globodns'
-          host:             ''
-          #host:             'slave0' ### empty means you don't have slave
-          ipaddr:           '172.16.0.3'
-          port:             53
-          rndc_port:        954
-          chroot_dir:       '/etc/named'
-          zones_dir:        '/var/named'
-          #zones_dir:        '/etc/named'
+          host:             'slave0' ### empty means you don't have slave
+          ipaddr:           '192.168.0.101'
+          port:             5354
+          rndc_port:        5954
+          chroot_dir:       '/var/named/chroot'
+          zones_dir:        '/etc/named'
           named_conf_file:  '/etc/named/named.conf'  # must be inside zones_dir
           named_conf_link:  '/etc/named.conf'  # can be anywhere
           export_chroot_dir: <%= Rails.root.join('tmp', 'named', 'chroot_slave1') %>
 
         - user:             'globodns'
-          host:             '' ### empty means you don't have slave
+          host:             'slave1' ### empty means you don't have slave
           ipaddr:           '192.168.0.102'
           port:             5354
           rndc_port:        5954
@@ -55,7 +53,6 @@ development: &devconf
     slaves_file:            'slaves.conf'
     forwards_dir:           'forwards'
     forwards_file:          'forwards.conf'
-    views_dir:              'views'
     views_file:             'views.conf'
     subdir_depth:           3
 

--- a/config/globodns.yml
+++ b/config/globodns.yml
@@ -6,11 +6,9 @@ development: &devconf
         ipaddr:          '127.0.0.1'
         port:            53
         rndc_port:       953
-        #chroot_dir:      '/etc/named'
         chroot_dir:      '/var/named/chroot'
         zones_dir:       '/var/named' 
-        named_conf_file: "/etc/named/named.conf"  # must be inside zones_dir
-        named_conf_link: '/etc/named.conf'  # can be anywhere
+        named_conf_file: "/etc/named.conf"
         export_chroot_dir:    <%= Rails.root.join('tmp', 'named', 'chroot_master') %>
 
       slaves:
@@ -24,7 +22,6 @@ development: &devconf
           zones_dir:        '/var/named'
           #zones_dir:        '/etc/named'
           named_conf_file:  '/etc/named/named.conf'  # must be inside zones_dir
-          named_conf_link:  '/etc/named.conf'  # can be anywhere
           export_chroot_dir: <%= Rails.root.join('tmp', 'named', 'chroot_slave1') %>
 
         - user:             'globodns'
@@ -35,7 +32,6 @@ development: &devconf
           chroot_dir:       '/var/named/chroot'
           zones_dir:        '/etc/named'
           named_conf_file:  '/etc/named/named.conf'  # must be inside zones_dir
-          named_conf_link:  '/etc/named.conf'  # can be anywhere
           export_chroot_dir: <%= Rails.root.join('tmp', 'named', 'chroot_slave2') %>
 
     bind_user:                   'named'

--- a/config/globodns.yml
+++ b/config/globodns.yml
@@ -2,30 +2,32 @@ development: &devconf
     bind:
       master:
         user:            'globodns'
-        host:            'master'
-        ipaddr:          '192.168.0.100'
+        host:            'dns01'
+        ipaddr:          '127.0.0.1'
         port:            53
         rndc_port:       953
-        chroot_dir:      '/var/named/chroot'
-        zones_dir:       '/etc/named'
-        named_conf_file: '/etc/named/named.conf'  # must be inside zones_dir
+        chroot_dir:      '/etc/named'
+        zones_dir:       '/var/named'
+        named_conf_file: '/etc/named.conf'  # must be inside zones_dir
         named_conf_link: '/etc/named.conf'  # can be anywhere
         export_chroot_dir:    <%= Rails.root.join('tmp', 'named', 'chroot_master') %>
 
       slaves:
         - user:             'globodns'
-          host:             'slave0' ### empty means you don't have slave
-          ipaddr:           '192.168.0.101'
-          port:             5354
-          rndc_port:        5954
-          chroot_dir:       '/var/named/chroot'
-          zones_dir:        '/etc/named'
+          host:             ''
+          #host:             'slave0' ### empty means you don't have slave
+          ipaddr:           '172.16.0.3'
+          port:             53
+          rndc_port:        954
+          chroot_dir:       '/etc/named'
+          zones_dir:        '/var/named'
+          #zones_dir:        '/etc/named'
           named_conf_file:  '/etc/named/named.conf'  # must be inside zones_dir
           named_conf_link:  '/etc/named.conf'  # can be anywhere
           export_chroot_dir: <%= Rails.root.join('tmp', 'named', 'chroot_slave1') %>
 
         - user:             'globodns'
-          host:             'slave1' ### empty means you don't have slave
+          host:             '' ### empty means you don't have slave
           ipaddr:           '192.168.0.102'
           port:             5354
           rndc_port:        5954
@@ -53,6 +55,7 @@ development: &devconf
     slaves_file:            'slaves.conf'
     forwards_dir:           'forwards'
     forwards_file:          'forwards.conf'
+    views_dir:              'views'
     views_file:             'views.conf'
     subdir_depth:           3
 

--- a/config/globodns.yml
+++ b/config/globodns.yml
@@ -6,9 +6,10 @@ development: &devconf
         ipaddr:          '127.0.0.1'
         port:            53
         rndc_port:       953
-        chroot_dir:      '/etc/named'
+        #chroot_dir:      '/etc/named'
+        chroot_dir:      '/var/named/chroot'
         zones_dir:       '/var/named'
-        named_conf_file: '/etc/named.conf'  # must be inside zones_dir
+        named_conf_file: '/etc/named/named.conf'  # must be inside zones_dir
         named_conf_link: '/etc/named.conf'  # can be anywhere
         export_chroot_dir:    <%= Rails.root.join('tmp', 'named', 'chroot_master') %>
 

--- a/config/globodns.yml
+++ b/config/globodns.yml
@@ -7,7 +7,9 @@ development: &devconf
         port:            53
         rndc_port:       953
         #chroot_dir:      '/etc/named'
-        chroot_dir:      '/var/named/chroot'
+        chroot_dir:      '/'
+        #chroot_dir:      '/var/named/chroot'
+        named_conf_dir:  '/etc/named'
         zones_dir:       '/var/named'
         named_conf_file: '/etc/named/named.conf'  # must be inside zones_dir
         named_conf_link: '/etc/named.conf'  # can be anywhere

--- a/lib/globo_dns/exporter.rb
+++ b/lib/globo_dns/exporter.rb
@@ -131,8 +131,10 @@ class Exporter
         # recursivelly copy the current configuration to the tmp dir
         exec('rsync chroot', 'rsync', '-v', '-a', '--exclude', 'session.key', '--exclude', '.git/', File.join(chroot_dir, '.'), tmp_dir)
 
+	puts "HHHHHHHH#{chroot_dir} #{named_conf_file}"
         # export main configuration file
         named_conf_content = self.class.load_named_conf(chroot_dir, named_conf_file) if named_conf_content.blank?
+	puts "HHHHHHHH#{named_conf_content}"
         export_named_conf(named_conf_content, tmp_dir, zones_root_dir, named_conf_file)
 
         # export all views

--- a/lib/globo_dns/exporter.rb
+++ b/lib/globo_dns/exporter.rb
@@ -131,10 +131,8 @@ class Exporter
         # recursivelly copy the current configuration to the tmp dir
         exec('rsync chroot', 'rsync', '-v', '-a', '--exclude', 'session.key', '--exclude', '.git/', File.join(chroot_dir, '.'), tmp_dir)
 
-	puts "HHHHHHHH#{chroot_dir} #{named_conf_file}"
         # export main configuration file
         named_conf_content = self.class.load_named_conf(chroot_dir, named_conf_file) if named_conf_content.blank?
-	puts "HHHHHHHH#{named_conf_content}"
         export_named_conf(named_conf_content, tmp_dir, zones_root_dir, named_conf_file)
 
         # export all views

--- a/lib/globo_dns/exporter.rb
+++ b/lib/globo_dns/exporter.rb
@@ -439,7 +439,7 @@ class Exporter
     end
 
     def sync_remote_bind_and_reload(chroot_dir, zones_root_dir, named_conf_file, bind_server_data, updated_zones)
-        abs_repository_zones_dir = File.join(chroot_dir, zones_root_dir, '')
+        abs_repository_zones_dir = File.join(chroot_dir, zones_root_dir)
         sync_remote(abs_repository_zones_dir , named_conf_file, bind_server_data)
 
         @to_reload = updated_zones

--- a/lib/globo_dns/exporter.rb
+++ b/lib/globo_dns/exporter.rb
@@ -58,12 +58,12 @@ class Exporter
         end
 
         syslog_info('export successful')
-        Notifier.export_successful(@logger.string).deliver if @something_exported
+        Notifier.export_successful(@logger.string).deliver_now if @something_exported
     rescue Exception => e
         @logger.error(e.to_s + e.backtrace.join("\n"))
 
         syslog_error('export failed')
-        Notifier.export_failed("#{e}\n\n#{@logger.string}\n\nBacktrace:\n#{e.backtrace.join("\n")}").deliver
+        Notifier.export_failed("#{e}\n\n#{@logger.string}\n\nBacktrace:\n#{e.backtrace.join("\n")}").deliver_now
 
         raise e
     ensure

--- a/lib/globo_dns/importer.rb
+++ b/lib/globo_dns/importer.rb
@@ -31,7 +31,6 @@ class Importer
         slaves_chroot_dirs      = options.delete(:slave_chroot_dir)       || Bind::Slaves.map { |slave| slave::CHROOT_DIR }
         slaves_named_conf_paths = options.delete(:slave_named_conf_file)  || Bind::Slaves.map { |slave| slave::NAMED_CONF_FILE }
         @logger                 = GloboDns::StringIOLogger.new(options.delete(:logger) || Rails.logger)
-        @logger.level           = Logger::DEBUG if options[:debug]
         slaves_canonical_named_conf = []
 
         if options[:remote]

--- a/lib/globo_dns/importer.rb
+++ b/lib/globo_dns/importer.rb
@@ -136,6 +136,7 @@ class Importer
         master_root = nil
         begin
             master_root = NamedConf.parse(master_canonical_named_conf)
+	    master_root.inspect
         rescue Citrus::ParseError => e
             raise RuntimeError.new("[ERROR] unable to parse canonical master BIND configuration #{master_canonical_named_conf} (line #{e.line_number}, column #{e.line_offset}: #{e.line})")
         end
@@ -257,7 +258,8 @@ class Importer
                                               :abort_on_rndc_failure => false,
                                               :logger                => logger)
         else
-            save_config(master_config, Bind::Master::EXPORT_CHROOT_DIR, Bind::Master::ZONES_DIR, Bind::Master::NAMED_CONF_FILE, import_timestamp)
+            #save_config(master_config, Bind::Master::EXPORT_CHROOT_DIR, Bind::Master::ZONES_DIR, Bind::Master::NAMED_CONF_FILE, import_timestamp)
+            save_config(master_config, Bind::Master::EXPORT_CHROOT_DIR, '/etc/named' , Bind::Master::NAMED_CONF_FILE, import_timestamp)
             Bind::Slaves.each_with_index do |slave, index|
                 save_config(slaves_configs[index],  slave::EXPORT_CHROOT_DIR,  slave::ZONES_DIR,  slave::NAMED_CONF_FILE,  import_timestamp) if SLAVE_ENABLED?
             end
@@ -287,8 +289,8 @@ class Importer
     end
 
     # saves *and commits the changes to git*
-    def save_config(content, chroot_dir, zones_dir, named_conf_file, timestamp)
-        Dir.chdir(File.join(chroot_dir, zones_dir)) do
+    def save_config(content, chroot_dir, target_dir, named_conf_file, timestamp)
+        Dir.chdir(File.join(chroot_dir, target_dir)) do
             File.open(File.basename(named_conf_file), 'w') do |file|
                 file.write(content)
                 file.puts GloboDns::Exporter::CONFIG_START_TAG

--- a/lib/globo_dns/importer.rb
+++ b/lib/globo_dns/importer.rb
@@ -264,10 +264,10 @@ class Importer
         end
 
         syslog_info('import successful')
-        Notifier.import_successful(logger).deliver
+        Notifier.import_successful(logger).deliver_now
     rescue Exception => e
         syslog_error 'import failed'
-        Notifier.import_failed("#{e}\n\n#{logger}\n\nBacktrace:\n#{e.backtrace.join("\n")}").deliver
+        Notifier.import_failed("#{e}\n\n#{logger}\n\nBacktrace:\n#{e.backtrace.join("\n")}").deliver_now
         raise e
     # ensure
         # FileUtils.remove_entry_secure master_tmp_dir unless master_tmp_dir.nil? || @options[:keep_tmp_dir] == true

--- a/lib/globo_dns/importer.rb
+++ b/lib/globo_dns/importer.rb
@@ -258,9 +258,10 @@ class Importer
                                               :logger                => logger)
         else
             #save_config(master_config, Bind::Master::EXPORT_CHROOT_DIR, Bind::Master::ZONES_DIR, Bind::Master::NAMED_CONF_FILE, import_timestamp)
-            save_config(master_config, Bind::Master::EXPORT_CHROOT_DIR, '/etc/named' , Bind::Master::NAMED_CONF_FILE, import_timestamp)
+            save_config(master_config, Bind::Master::EXPORT_CHROOT_DIR, File.dirname(Bind::Master::NAMED_CONF_FILE) , Bind::Master::NAMED_CONF_FILE, import_timestamp)
             Bind::Slaves.each_with_index do |slave, index|
-                save_config(slaves_configs[index],  slave::EXPORT_CHROOT_DIR,  slave::ZONES_DIR,  slave::NAMED_CONF_FILE,  import_timestamp) if SLAVE_ENABLED?
+                #save_config(slaves_configs[index],  slave::EXPORT_CHROOT_DIR,  slave::ZONES_DIR,  slave::NAMED_CONF_FILE,  import_timestamp) if SLAVE_ENABLED?
+                save_config(slaves_configs[index],  slave::EXPORT_CHROOT_DIR,  File.dirname(slave::NAMED_CONF_FILE),  slave::NAMED_CONF_FILE,  import_timestamp) if SLAVE_ENABLED?
             end
         end
 

--- a/lib/globo_dns/importer.rb
+++ b/lib/globo_dns/importer.rb
@@ -136,7 +136,6 @@ class Importer
         master_root = nil
         begin
             master_root = NamedConf.parse(master_canonical_named_conf)
-	    master_root.inspect
         rescue Citrus::ParseError => e
             raise RuntimeError.new("[ERROR] unable to parse canonical master BIND configuration #{master_canonical_named_conf} (line #{e.line_number}, column #{e.line_offset}: #{e.line})")
         end

--- a/lib/tasks/globodns.rake
+++ b/lib/tasks/globodns.rake
@@ -41,6 +41,7 @@ namespace :globodns do
 
                 Dir.chdir(File.join(base, zones_dir)) do
                     exec('git init',   'git', 'init', '.')
+		    File.write("README.md", "dummy")
                     exec('git add',    'git', 'add', '.')
                     exec('git commit', 'git', 'commit', "--date=#{Time.local(2012, 1, 1, 0, 0, 0).to_i}", "--author=#{GIT_AUTHOR}", '-m', 'Initial commit.')
                 end

--- a/lib/tasks/globodns.rake
+++ b/lib/tasks/globodns.rake
@@ -39,6 +39,8 @@ namespace :globodns do
                         named_link_path.relative_path_from(base_path).to_s, :verbose => true
         		end
 
+                FileUtils.chown_R(Bind::Master::USER, BIND_GROUP, base_path)
+
                 Dir.chdir(File.join(base, zones_dir)) do
                     exec('git init',   'git', 'init', '.')
 		    File.write("README.md", "dummy")

--- a/lib/tasks/globodns.rake
+++ b/lib/tasks/globodns.rake
@@ -29,21 +29,19 @@ namespace :globodns do
                 FileUtils.mkdir_p(File.join(base, 'var', 'run', 'named'))
                 FileUtils.mkdir_p(File.join(base, 'var', 'tmp'))
 
-        		base_path = Pathname.new base
+                base_path = Pathname.new base
                 named_file_path = Pathname.new File.join(base, named_conf_file)
                 named_link_path = Pathname.new File.join(base, named_conf_link)
-        		Dir.chdir(base) do
+                Dir.chdir(base) do
                     FileUtils.touch named_file_path.relative_path_from(base_path).to_s, :verbose => true
-    
-                    FileUtils.ln_s named_file_path.relative_path_from(named_link_path.parent).to_s, \
-                        named_link_path.relative_path_from(base_path).to_s, :verbose => true
-        		end
+                end
 
                 FileUtils.chown_R(Bind::Master::USER, BIND_GROUP, base_path)
 
                 Dir.chdir(File.join(base, zones_dir)) do
                     exec('git init',   'git', 'init', '.')
-		    File.write("README.md", "dummy")
+                    # To fix commit error which is occurred if the directory is empty
+                    File.write("README.md", "dummy")
                     exec('git add',    'git', 'add', '.')
                     exec('git commit', 'git', 'commit', "--date=#{Time.local(2012, 1, 1, 0, 0, 0).to_i}", "--author=#{GIT_AUTHOR}", '-m', 'Initial commit.')
                 end

--- a/lib/tasks/globodns.rake
+++ b/lib/tasks/globodns.rake
@@ -7,7 +7,7 @@ namespace :globodns do
             include GloboDns::Config
             include GloboDns::Util
 
-            def create_chroot_dir(base, zones_dir, named_conf_file, named_conf_link)
+            def create_chroot_dir(base, zones_dir, named_conf_file)
                 File.exists?(base) and raise RuntimeError.new("[ERROR] chroot dir \"#{base}\" already exists")
                 FileUtils.mkdir_p(base)
                 FileUtils.mkdir_p(File.join(base, 'dev'))
@@ -31,7 +31,6 @@ namespace :globodns do
 
                 base_path = Pathname.new base
                 named_file_path = Pathname.new File.join(base, named_conf_file)
-                named_link_path = Pathname.new File.join(base, named_conf_link)
                 Dir.chdir(base) do
                     FileUtils.touch named_file_path.relative_path_from(base_path).to_s, :verbose => true
                 end
@@ -47,10 +46,10 @@ namespace :globodns do
                 end
             end
 
-            create_chroot_dir(Bind::Master::EXPORT_CHROOT_DIR, Bind::Master::ZONES_DIR, Bind::Master::NAMED_CONF_FILE, Bind::Master::NAMED_CONF_LINK)
+            create_chroot_dir(Bind::Master::EXPORT_CHROOT_DIR, Bind::Master::ZONES_DIR, Bind::Master::NAMED_CONF_FILE)
             if SLAVE_ENABLED?
                 Bind::Slaves.each do |slave|
-                    create_chroot_dir(slave::EXPORT_CHROOT_DIR,  slave::ZONES_DIR,  slave::NAMED_CONF_FILE,  slave::NAMED_CONF_LINK)
+                    create_chroot_dir(slave::EXPORT_CHROOT_DIR,  slave::ZONES_DIR,  slave::NAMED_CONF_FILE)
                 end
             end
         end


### PR DESCRIPTION
The reason I removed a line which starts with @logger.level, cause there is no level attribute in the GloboDns::StringIOLogger class.
